### PR TITLE
Add Current account to accepted Cheque account types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fnb-api",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "clear && ts-node --project tsconfig.test.json ./test/index.ts"
+    "test": "clear && ts-node --project tsconfig.test.json ./test/index.ts",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/scrapers/scrape-util.ts
+++ b/src/scrapers/scrape-util.ts
@@ -2,7 +2,7 @@ import { AccountType } from '../models/account-type'
 import { Page } from 'puppeteer'
 
 export const getAccountType = (text: string, hasEngineNumber: boolean) => {
-	if (text.indexOf('Cheque') !== -1 || text.indexOf('Business Account') !== -1 || text.indexOf('Fusion') !== -1) {
+	if (text.indexOf('Cheque') !== -1 || text.indexOf('Business Account') !== -1 || text.indexOf('Fusion') !== -1 || text.indexOf('Current') !== -1) {
 		return AccountType.Cheque
 	}
 


### PR DESCRIPTION
The `accountTypeString` for a Private Wealth Cheque account is `FNB Private Wealth Current Account` which is not picked up by this. Adding `Current` to the list of accepted account types for a `Cheque` account allows transactions to be picked up successfully.